### PR TITLE
Bugfix/channel timeouts should be consistent

### DIFF
--- a/benchmarks/unbuffered_channel.zig
+++ b/benchmarks/unbuffered_channel.zig
@@ -24,7 +24,7 @@ const BenchmarkUnbufferedChannelSendReceive = struct {
     pub fn run(self: Self, _: std.mem.Allocator) void {
         for (self.list.items) |data| {
             self.channel.send(data);
-            const v = self.channel.timedReceive(1 * std.time.ns_per_ms) catch unreachable;
+            const v = self.channel.tryReceive(1 * std.time.ns_per_ms) catch unreachable;
             assert(v == data);
         }
     }
@@ -35,7 +35,7 @@ var simple_channel: UnbufferedChannel(usize) = undefined;
 var data_list: std.ArrayList(usize) = undefined;
 const allocator = testing.allocator;
 
-test "SimpleChannel benchmarks" {
+test "UnbufferedChannel benchmarks" {
     var bench = zbench.Benchmark.init(
         std.testing.allocator,
         .{ .iterations = constants.benchmark_max_iterations },

--- a/examples/mpmc_bus.zig
+++ b/examples/mpmc_bus.zig
@@ -24,8 +24,8 @@ const BUS_QUEUE_SIZE = 5_000;
 const PRODUCER_QUEUE_SIZE = 5_000;
 const CONSUMER_QUEUE_SIZE = 5_000;
 const ITERATIONS = 10_000;
-const CONSUMER_COUNT = 100;
-const PRODUCER_COUNT = 1;
+const CONSUMER_COUNT = 10;
+const PRODUCER_COUNT = 5;
 
 pub fn doProduce(
     producers: *std.ArrayList(*Producer(VALUE_TYPE)),
@@ -179,7 +179,7 @@ pub fn Bus(comptime T: type) type {
             ready.send(true);
             while (true) {
                 // check if we have received a signale to close the topic
-                const signal = self.close_channel.timedReceive(0) catch false;
+                const signal = self.close_channel.tryReceive(0) catch false;
                 if (signal) {
                     return;
                 }
@@ -247,7 +247,7 @@ pub fn Consumer(comptime T: type) type {
             ready.send(true);
             while (true) {
                 // check if we have received a signale to close the topic
-                const signal = self.close_channel.timedReceive(0) catch false;
+                const signal = self.close_channel.tryReceive(0) catch false;
                 if (signal) {
                     return;
                 }

--- a/examples/mpmc_bus.zig
+++ b/examples/mpmc_bus.zig
@@ -20,12 +20,12 @@ const sardine = Dog{
 
 // This is the type that will be processed
 const VALUE_TYPE: type = *const Dog;
-const BUS_QUEUE_SIZE = 5_000;
-const PRODUCER_QUEUE_SIZE = 5_000;
-const CONSUMER_QUEUE_SIZE = 5_000;
-const ITERATIONS = 10_000;
+const BUS_QUEUE_SIZE = 1_000;
+const PRODUCER_QUEUE_SIZE = 1_000;
+const CONSUMER_QUEUE_SIZE = 1_000;
+const ITERATIONS = 1_000;
 const CONSUMER_COUNT = 10;
-const PRODUCER_COUNT = 5;
+const PRODUCER_COUNT = 1;
 
 pub fn doProduce(
     producers: *std.ArrayList(*Producer(VALUE_TYPE)),

--- a/examples/mpmc_bus.zig
+++ b/examples/mpmc_bus.zig
@@ -20,12 +20,12 @@ const sardine = Dog{
 
 // This is the type that will be processed
 const VALUE_TYPE: type = *const Dog;
-const BUS_QUEUE_SIZE = 1_000;
-const PRODUCER_QUEUE_SIZE = 1_000;
+const BUS_QUEUE_SIZE = 100_000;
+const PRODUCER_QUEUE_SIZE = 10_000;
 const CONSUMER_QUEUE_SIZE = 1_000;
-const ITERATIONS = 1_000;
-const CONSUMER_COUNT = 10;
-const PRODUCER_COUNT = 1;
+const ITERATIONS = 10_000;
+const CONSUMER_COUNT = 100;
+const PRODUCER_COUNT = 10;
 
 pub fn doProduce(
     producers: *std.ArrayList(*Producer(VALUE_TYPE)),

--- a/examples/mpmc_queue.zig
+++ b/examples/mpmc_queue.zig
@@ -21,11 +21,11 @@ const sardine = Dog{
 // This is the type that will be processed
 const VALUE_TYPE: type = *const Dog;
 const TOPIC_QUEUE_SIZE = 10_000;
-const PRODUCER_QUEUE_SIZE = 1_000;
-const WORKER_QUEUE_SIZE = 1_000;
-const ITERATIONS = 1_000;
-const WORKER_COUNT = 10;
-const PRODUCER_COUNT = 1;
+const PRODUCER_QUEUE_SIZE = 5_0000;
+const WORKER_QUEUE_SIZE = 5_000;
+const ITERATIONS = 100_000;
+const WORKER_COUNT = 100;
+const PRODUCER_COUNT = 100;
 const PRODUCER_BACKPRESSURE_MAX_CAPACITY = PRODUCER_QUEUE_SIZE * 10;
 
 pub fn Topic(comptime T: type) type {
@@ -113,7 +113,6 @@ pub fn Producer(comptime T: type) type {
             };
 
             self.produced_count += 1;
-            log.err("producer enqueue here", .{});
         }
 
         pub fn tick(self: *Self) !void {

--- a/examples/mpmc_queue.zig
+++ b/examples/mpmc_queue.zig
@@ -113,6 +113,7 @@ pub fn Producer(comptime T: type) type {
             };
 
             self.produced_count += 1;
+            log.err("producer enqueue here", .{});
         }
 
         pub fn tick(self: *Self) !void {
@@ -268,6 +269,7 @@ pub fn main() !void {
         th.detach();
 
         _ = ready_channel.receive();
+        log.debug("producer {} ready", .{producer.id});
     }
 
     for (workers.items) |worker| {
@@ -281,6 +283,7 @@ pub fn main() !void {
         th.detach();
 
         _ = ready_channel.receive();
+        log.debug("worker {} ready", .{worker.id});
     }
 
     var timer = try std.time.Timer.start();

--- a/examples/mpmc_queue.zig
+++ b/examples/mpmc_queue.zig
@@ -20,12 +20,12 @@ const sardine = Dog{
 
 // This is the type that will be processed
 const VALUE_TYPE: type = *const Dog;
-const TOPIC_QUEUE_SIZE = 50_000;
-const PRODUCER_QUEUE_SIZE = 10_000;
-const WORKER_QUEUE_SIZE = 10_000;
-const ITERATIONS = 10_000;
+const TOPIC_QUEUE_SIZE = 10_000;
+const PRODUCER_QUEUE_SIZE = 1_000;
+const WORKER_QUEUE_SIZE = 1_000;
+const ITERATIONS = 1_000;
 const WORKER_COUNT = 10;
-const PRODUCER_COUNT = 5;
+const PRODUCER_COUNT = 1;
 const PRODUCER_BACKPRESSURE_MAX_CAPACITY = PRODUCER_QUEUE_SIZE * 10;
 
 pub fn Topic(comptime T: type) type {

--- a/examples/mpmc_queue.zig
+++ b/examples/mpmc_queue.zig
@@ -23,9 +23,9 @@ const VALUE_TYPE: type = *const Dog;
 const TOPIC_QUEUE_SIZE = 50_000;
 const PRODUCER_QUEUE_SIZE = 10_000;
 const WORKER_QUEUE_SIZE = 10_000;
-const ITERATIONS = 1_000_000;
+const ITERATIONS = 10_000;
 const WORKER_COUNT = 10;
-const PRODUCER_COUNT = 1;
+const PRODUCER_COUNT = 5;
 const PRODUCER_BACKPRESSURE_MAX_CAPACITY = PRODUCER_QUEUE_SIZE * 10;
 
 pub fn Topic(comptime T: type) type {
@@ -140,7 +140,7 @@ pub fn Producer(comptime T: type) type {
             ready.send(true);
             while (true) {
                 // check if we have received a signale to close the topic
-                const signal = self.close_channel.timedReceive(0) catch false;
+                const signal = self.close_channel.tryReceive(0) catch false;
                 if (signal) {
                     // log.info("signal received to stop producer {}", .{self.id});
                     // log.debug("producer {}: produced {} items", .{ self.id, self.produced_count });
@@ -205,7 +205,7 @@ pub fn Worker(comptime T: type) type {
             ready.send(true);
             while (true) {
                 // check if we have received a signale to close the topic
-                const signal = self.close_channel.timedReceive(0) catch false;
+                const signal = self.close_channel.tryReceive(0) catch false;
                 if (signal) {
                     // log.err("signal received to stop worker {}", .{self.id});
                     // log.err("worker {}: processed {} items", .{ self.id, self.processed_count });
@@ -333,11 +333,15 @@ pub fn main() !void {
     for (producers.items) |producer| {
         log.err("producer {} produced {}", .{ producer.id, producer.produced_count });
         producer.close();
+        producer.deinit();
+        allocator.destroy(producer);
     }
 
     for (workers.items) |worker| {
         log.err("worker {} processed {}", .{ worker.id, worker.processed_count });
         worker.close();
+        worker.deinit();
+        allocator.destroy(worker);
     }
 
     assert(processed_count == produced_count);


### PR DESCRIPTION
Fixes unbuffered channel waits. This was causing a bunch of issues that caused massive wait times for the examples